### PR TITLE
Workaround for kde-apps/cantor builds failing and app-misc/openrgb segmentation fault on launch

### DIFF
--- a/sys-config/ltoize/files/package.cflags/lto.conf
+++ b/sys-config/ltoize/files/package.cflags/lto.conf
@@ -157,6 +157,7 @@ sys-apps/sandbox *FLAGS-=-flto* # Issue #347, LTO breaks basic sandboxing functi
 sys-fs/cryfs *FLAGS-=-flto* # Test failure
 sys-libs/libapparmor *FLAGS-=-flto* # Undefined symbol error when trying to compile sys-apps/apparmor
 sys-libs/libxcrypt *FLAGS-=-flto* # Undefined symbols in library files cause dependencies like net-misc/whois to fail to build
+app-misc/openrgb *FLAGS-=-flto* # Segmentation fault on launch
 # END: LTO not recommended
 
 # BEGIN: Build Workarounds

--- a/sys-config/ltoize/files/package.cflags/optimizations.conf
+++ b/sys-config/ltoize/files/package.cflags/optimizations.conf
@@ -6,6 +6,7 @@ media-libs/lcms /-O3/-O2 # Test failure
 net-misc/dhcp /-O3/-O2 # Runtime failure, DHCPDISCOVER doesn't work correctly - introduced with gcc 10?
 sci-libs/scotch /-O3/-O2 # Test failure
 sys-apps/systemd /-O3/-O2 # causes homectl to fail with protocol error
+kde-apps/cantor /-O3/-O2 # Build fails with error
 # END: Deliberate -O3 workarounds
 
 # BEGIN: -Ofast workarounds


### PR DESCRIPTION
Title: app-misc/openrgb: segmentation fault will occur on launch with LTO enabled
         kde-apps/cantor: will not build with -O3

app-misc/openrgb will complete build successfully however will generate a core dump due to a segmentation fault, on launch.

kde-apps/cantor will not build at all with -O3 but with -O2, will finish build and function normally.